### PR TITLE
changed the sed command delimiter

### DIFF
--- a/.github/workflows/manual-delivery.yml
+++ b/.github/workflows/manual-delivery.yml
@@ -108,8 +108,8 @@ jobs:
           B64_STORAGE_KEY=$(echo -n "${{ env.AZURE_STORAGE_KEY }}" | base64)
           
           # Use sed to replace the empty values in the secrets file
-          sed -i "s/AZURE_STORAGE_ACCOUNT_NAME: \"\"/AZURE_STORAGE_ACCOUNT_NAME: \"$B64_STORAGE_NAME\"/g" k8s/secrets.yaml
-          sed -i "s/AZURE_STORAGE_ACCOUNT_KEY: \"\"/AZURE_STORAGE_ACCOUNT_KEY: \"$B64_STORAGE_KEY\"/g" k8s/secrets.yaml
+          sed -i "s|AZURE_STORAGE_ACCOUNT_NAME: \"\"|AZURE_STORAGE_ACCOUNT_NAME: \"$B64_STORAGE_NAME\"|g" k8s/secrets.yaml
+          sed -i "s|AZURE_STORAGE_ACCOUNT_KEY: \"\"|AZURE_STORAGE_ACCOUNT_KEY: \"$B64_STORAGE_KEY\"|g" k8s/secrets.yaml
           
           echo "secrets.yaml configured."
 


### PR DESCRIPTION
fixed cause of workflow error because of sed command delimiter. storage account key may contain forward slash, which was the delimiter earlier. changed it to pipe.

Ref: https://stackoverflow.com/questions/13195143/range-of-valid-character-for-a-base-64-encoding